### PR TITLE
Add the ability to pre-fill the page with code

### DIFF
--- a/apml.js
+++ b/apml.js
@@ -46,10 +46,22 @@ function fontSize(){
 }
 
 /*
-* Load sample from hard-coded global var
+ * pass ?code=TEXT in the URL to prefill the page with a specific example.
+ */
+function getCodeFromURL() {
+  try {
+    return new URL(document.URL).searchParams.get('code')
+  } catch {
+    return null;
+ }
+}
+
+/*
+* Load sample from hard-coded global var, or pre-filled via the URL
 */
 function loadSample(){
-  $("#code").val(sampleCode);
+  urlCode = getCodeFromURL();
+  $("#code").val(urlCode || sampleCode);
   convert();
 }
 


### PR DESCRIPTION
This lets you open the page with a URL that contains the code to put in the text box. 

Yes, this will be an ugly URL for most code, but it will make it helpful to share examples and we can then open up a page from within Snap! that lets you convert Snap! blocks to APML that will render images.

i.e. /apml/?code=%5Buser%20%3C-%20%5BINPUT%5D%5D%0A%5Brand%20%3C-%20%5BRANDOM%20%7C1%20%2C%2010%7C%5D%5D%0A%5BREPEAT%20UNTIL%20(user%20%3D%20rand)%0A%20%20%5B%5BDISPLAY%20%7C%22Guess%20Again!%22%7C%5D%0A%5BIF%20(%20user%20%3C%20rand%20)%0A%20%20%5B%5BDISPLAY%20%7C%22Higher!%22%7C%5D%5D%0AELSE%20%0A%20%20%5B%5BDISPLAY%20%7C%22Lower!%22%7C%5D%5D%0A%5D%0A%5Buser%20%3C-%20%5BINPUT%5D%5D%5D%0A%5D%0A%5BDISPLAY%20%7C%22You%20got%20it!%22%7C%5D